### PR TITLE
Change SMTPClient.send_mail function to allow configuration of SMTP Auth

### DIFF
--- a/app/notify.py
+++ b/app/notify.py
@@ -29,7 +29,8 @@ class SMTPClient:
     ) -> None:
         client = SMTP(self._server, self._port)
         client.starttls()
-        client.login(self._username, self._password)
+        if (self._password is not None): # Only login if password is supplied
+            client.login(self._username, self._password)
         client.sendmail(sender, receivers, message.as_string())
         client.quit()
 


### PR DESCRIPTION
This PR modifies notify.py to only invoke the SMTP client.login() step if a password is provided in the app config, allowing for use of SMTP servers which do not require (or support) authentication.

If code style is not in line with the rest of the project then feel free to modify.

Resolves #23 