### PR TITLE
chore: bump CI actions to node24 and add Docker login/push retry

### DIFF
--- a/.agent-docs/agent.md
+++ b/.agent-docs/agent.md
@@ -1,0 +1,69 @@
+# Agent Behavioural Standards
+
+These standards apply to all AI agent work in this repository. Follow them on every task.
+
+---
+
+## 1. Ownership and Independence
+
+- Take ownership of a task from start to finish with minimal handholding. Clarify ambiguity, scope the work, implement it, verify it locally, and confirm it works in the target environment.
+- Know when to ask for help. Try for a reasonable period, but do not stall in silence. When you ask, include what you tried, what you expected, and what happened.
+- Recognise when a task is larger than initially scoped and surface this early. Do not produce oversized changes — break work into smaller increments.
+- Deliver consistently against the stated scope. Make your effort estimates broadly reliable.
+
+---
+
+## 2. Production Code Quality
+
+- Write readable code above all else. Write self-documenting code. Use comments only to explain complex functionality — not to restate what the code does.
+- Favour clarity over brevity. Prefer maintainability over micro-efficiency.
+- Give every function and class a single, clear responsibility. Keep methods short enough that their behaviour is understood without extensive scrolling.
+- Name everything descriptively. Choose names for variables, methods, classes, and files that communicate intent without requiring the reader to open another file.
+- Never hardcode values, magic numbers, secrets, credentials, URLs, or environment-specific strings. Use secret-safe configuration.
+- Never leave commented-out code, dead code, or deprecated code in committed changes. Replace unnecessary TODOs with proper work items — do not leave them in the codebase.
+- Never leave debug output (`console.log`, `print`, `System.out.println`, etc.) in committed code.
+- Handle errors deliberately. Understand the possible failure states, handle them explicitly, and test for them. Never swallow errors or re-throw them blindly.
+- Catch common pitfalls before raising any PR: N+1 queries, unbounded loops, leaked secrets, unsanitised input.
+- Use logging levels (`info`, `debug`, `warning`, `error`) appropriately. Write log messages that are meaningful.
+- Follow the existing patterns and conventions of the codebase. Introduce new patterns slowly, with good reason and explicit agreement.
+- Treat performance, security, and observability as part of every task — not afterthoughts.
+
+---
+
+## 3. Testing Discipline
+
+- Accompany any change to execution logic with tests. If code can be changed without tests failing, the current test coverage is insufficient.
+- Write unit tests that cover happy paths and meaningful edge cases: empty inputs, boundary conditions, error paths, and all execution branches introduced by your change.
+- Write tests that verify behaviour, not implementation. Do not test internal structure — tests that verify implementation details have no value.
+- Write deterministic tests. Do not rely on real network calls, real clocks, or shared mutable state. Mock only at system boundaries — never mock code you control.
+- Ensure all tests pass locally before raising any PR. Do not raise a PR with a failing pipeline.
+- Add integration and/or contract tests where a change is integration-heavy.
+- Maintain a minimum of 80% code coverage, enforced at the pipeline level. Prioritise meaningful coverage of business logic over hitting the number with implementation tests.
+
+---
+
+## 4. Source Control and Git Practice
+
+- Always branch from the latest `main` or `develop`. Name branches consistently: `feature/`, `bugfix/`, `hotfix/`, `chore/`. Confirm conventions when joining a new codebase.
+- Make commits small, logical, and with meaningful descriptive messages. Do not use loose messages (`fix`, `wip`, `update`) on reviewed branches.
+- Rebase or merge with the latest target branch before raising a PR. Resolve conflicts yourself — do not leave them for the reviewer.
+- Avoid long-lived feature branches. Break work down for incremental merging. Hide new UI behind feature flags rather than leaving it unmerged.
+- Keep PRs focused on one concern. Do not mix features, refactors, and unrelated fixes in a single PR.
+
+---
+
+## 5. Engineering Lifecycle
+
+- Understand the full path from work item to production: refinement → estimation → implementation → review → merge → deployment → monitoring.
+- Read acceptance criteria before starting. Clarify ambiguities upfront. Validate your implementation against acceptance criteria before raising a PR. Write acceptance criteria proactively when they are absent.
+- Act as the first line of behaviour verification — not QA. Test changes appropriately in the execution environment before requesting review.
+- Write PRs as handover artefacts. Write them for the reviewer so that the changes can be unambiguously understood.
+
+---
+
+## 6. Communication and Feedback
+
+- Surface blockers and scope changes proactively and early in your response — do not wait to be asked. Alert the team immediately if a deadline or scope commitment is at risk.
+- Treat review feedback as input to improve the work. Engage with it constructively.
+- Disagree with feedback through productive discussion and reasoning. Do not silently revert to the same pattern on the next task.
+- Contribute context and experience to team decisions. Every level has useful perspective to share.

--- a/.agent-docs/context.md
+++ b/.agent-docs/context.md
@@ -1,0 +1,29 @@
+# Bromley Bin Reminder
+
+A scheduled service that scrapes the Bromley Council waste-collection website and emails reminders for upcoming bin collections.
+
+## Language
+
+**WasteWorks page**:
+The Bromley Council-hosted webpage (`recyclingservices.bromley.gov.uk/waste`) that lists a household's upcoming bin collections. Rendered client-side, so it requires a headless browser rather than a plain HTTP fetch.
+_Avoid_: waste page, council page
+
+**Waste Collection**:
+A single scheduled pickup of one waste service (e.g. Food Waste) on a specific date, scraped from the WasteWorks page. Modelled by the `WasteCollection` dataclass.
+_Avoid_: bin day, pickup, collection event
+
+**Service**:
+One of the distinct categories of council-collected waste (Mixed Recycling, Paper & Cardboard, Non-Recyclable Refuse, Food Waste, Garden Waste). Garden Waste is an optional paid service; the others are standard.
+_Avoid_: waste type, bin type, category
+
+**Reminder**:
+The daily email notification sent for collections that are tomorrow or within the current reminder window. Triggered by the scheduled run comparing scraped collections against the current date.
+_Avoid_: notification, alert, email
+
+**Scraper**:
+The component (`WasteworksScraper`) that drives a headless Firefox browser via Selenium to render the WasteWorks page and extract collection data with BeautifulSoup.
+_Avoid_: crawler, parser
+
+**ENV_FLAG**:
+The environment variable selecting how the scraper launches its Firefox WebDriver — `local` (system-installed geckodriver) or `docker` (fixed path to a container-bundled geckodriver). Any other value is treated as unhandled and raises an error.
+_Avoid_: environment, mode

--- a/.agent-docs/issues/chore/node24-actions-docker-retry.md
+++ b/.agent-docs/issues/chore/node24-actions-docker-retry.md
@@ -1,0 +1,37 @@
+# Issues: chore/node24-actions-docker-retry
+
+## Harden ci-arm64.yml — Node 24 actions + Docker retry
+
+**Issue**: #255
+
+**Blocked by**: None
+
+**User stories**: 1, 2
+
+### What to build
+
+Update `.github/workflows/ci-arm64.yml` so it only uses `node24`-runtime GitHub Actions, and
+so the Docker Hub login/build/push step retries on transient failure instead of failing the
+whole build outright.
+
+Bump `actions/checkout` from `v2` to `v7`. Remove `docker/login-action` and
+`docker/build-push-action` entirely, replacing both with a single step that runs
+`docker login` (credentials via `env:`, piped via `--password-stdin`) and
+`docker buildx build --push --tag "$TAG" .` against the local checkout, wrapped in
+`nick-fields/retry@v4` (3 attempts, 15s wait, 5 minute timeout). Keep the existing
+branch-based tag logic (`dev` for non-`main`, `latest` for `main`) and the
+`DOCKER_IMAGE`/`DOCKER_REGISTRY` env vars unchanged.
+
+### Acceptance criteria
+
+- [ ] `actions/checkout@v2` is bumped to `actions/checkout@v7`
+- [ ] `docker/login-action` and `docker/build-push-action` no longer appear in the workflow
+- [ ] Docker login and build/push run as shell commands wrapped in `nick-fields/retry@v4`
+      (`max_attempts: 3`, `retry_wait_seconds: 15`, `timeout_minutes: 5`)
+- [ ] Docker Hub credentials are passed via the step's `env:` block, not as a CLI argument
+- [ ] The build uses the local checkout, not a remote `git#{sha}` context, with an inline
+      YAML comment explaining why
+- [ ] A pushed run of the workflow succeeds (`gh run watch`)
+- [ ] The run's logs contain no "Node.js 20 is deprecated" warning
+
+---

--- a/.agent-docs/issues/chore/node24-actions-docker-retry.md
+++ b/.agent-docs/issues/chore/node24-actions-docker-retry.md
@@ -1,5 +1,7 @@
 # Issues: chore/node24-actions-docker-retry
 
+> Work complete — PR ready to merge.
+
 ## Harden ci-arm64.yml — Node 24 actions + Docker retry
 
 **Issue**: #255
@@ -24,14 +26,14 @@ branch-based tag logic (`dev` for non-`main`, `latest` for `main`) and the
 
 ### Acceptance criteria
 
-- [ ] `actions/checkout@v2` is bumped to `actions/checkout@v7`
-- [ ] `docker/login-action` and `docker/build-push-action` no longer appear in the workflow
-- [ ] Docker login and build/push run as shell commands wrapped in `nick-fields/retry@v4`
+- [x] `actions/checkout@v2` is bumped to `actions/checkout@v7`
+- [x] `docker/login-action` and `docker/build-push-action` no longer appear in the workflow
+- [x] Docker login and build/push run as shell commands wrapped in `nick-fields/retry@v4`
       (`max_attempts: 3`, `retry_wait_seconds: 15`, `timeout_minutes: 5`)
-- [ ] Docker Hub credentials are passed via the step's `env:` block, not as a CLI argument
-- [ ] The build uses the local checkout, not a remote `git#{sha}` context, with an inline
+- [x] Docker Hub credentials are passed via the step's `env:` block, not as a CLI argument
+- [x] The build uses the local checkout, not a remote `git#{sha}` context, with an inline
       YAML comment explaining why
-- [ ] A pushed run of the workflow succeeds (`gh run watch`)
-- [ ] The run's logs contain no "Node.js 20 is deprecated" warning
+- [x] A pushed run of the workflow succeeds (`gh run watch`)
+- [x] The run's logs contain no "Node.js 20 is deprecated" warning
 
 ---

--- a/.agent-docs/specs/chore/node24-actions-docker-retry.md
+++ b/.agent-docs/specs/chore/node24-actions-docker-retry.md
@@ -1,0 +1,77 @@
+# CI: Node 24 Action Runtimes + Docker Login/Push Retry
+
+## Problem Statement
+
+The ARMv7 Docker Build/Publish workflow (`.github/workflows/ci-arm64.yml`) pins action
+versions (`actions/checkout@v2`, `docker/login-action@v2`, `docker/build-push-action@v4`)
+whose `action.yml` declares `using: node20`. GitHub removes Node 20 support from Actions
+runners entirely on 2026-09-16 — after that date these actions stop working outright, not
+just warn. Separately, the Docker Hub login/build/push steps have no retry: a transient DNS
+blip or momentary Docker Hub auth hiccup fails the whole build with no automatic recovery,
+requiring a manual re-push to notice and fix.
+
+## Solution
+
+Bump the pinned actions to versions confirmed `node24`, and replace the two Docker actions
+with plain shell commands wrapped in a retry action, so transient failures self-heal instead
+of failing the whole build.
+
+## User Stories
+
+1. As the repo maintainer, I want the CI workflow to use only Node 24-runtime actions, so
+   that builds keep working after GitHub removes Node 20 support on 2026-09-16.
+2. As the repo maintainer, I want the Docker Hub login/build/push step to retry on transient
+   failure, so that a momentary DNS or auth blip doesn't require me to notice a failed build
+   and manually re-push.
+
+## Implementation Decisions
+
+- `.github/workflows/ci-arm64.yml` is the only file in scope — this repo has no separate
+  `ci-checks.yml`/quality-check workflow to touch.
+- Action pin bumps (all confirmed `node24` via each tag's `action.yml`):
+  - `actions/checkout@v2` → `actions/checkout@v7`
+  - `docker/login-action@v2` and `docker/build-push-action@v4` are removed entirely (see below)
+- The job runs on the self-hosted `[ARM64]` runner. Confirmed via a recent run's log
+  (`Current runner version: '2.336.0'`) that this exceeds the `v2.327.1` minimum required for
+  Node 24 actions — no runner upgrade needed.
+- Replace the "Docker Login" and "Docker Build and Push" steps with a single retry-wrapped
+  shell step using `nick-fields/retry@v4` (confirmed `node24`): `max_attempts: 3`,
+  `retry_wait_seconds: 15`, `timeout_minutes: 5`.
+  - `docker login` reads `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` from the step's `env:` block
+    (not passed as a `--password` CLI arg) via `--password-stdin`.
+  - `docker buildx build --push --tag "$TAG" .` builds from the local checkout rather than a
+    remote `git#{sha}` context (the previous `docker/build-push-action` default). This is a
+    deliberate improvement — building from the already-checked-out working tree avoids a
+    second, separate fetch of the same commit, which was the confirmed root cause of a
+    transient CI failure in an earlier repo in this hardening series. Document this inline
+    with a YAML comment so it isn't "fixed" back to a remote-context build later.
+  - The existing branch-based tag logic (`dev` for non-`main`, `latest` for `main`) and the
+    `DOCKER_IMAGE`/`DOCKER_REGISTRY` env vars are unchanged.
+- `nick-fields/retry` only wraps raw shell `command:`, not other `uses:` actions — this is why
+  the two Docker actions are replaced with shell commands rather than wrapped directly.
+
+## Testing Decisions
+
+No application code or test suite is touched by this change — it is CI configuration only.
+Verification is direct execution, consistent with the rest of this hardening series:
+
+- Push the working branch and confirm via `gh run watch` that the Docker Build/Publish
+  workflow succeeds.
+- Confirm via `gh run view <run-id> --log | grep -i deprecat` that no "Node.js 20 is
+  deprecated" warning remains in the run's logs.
+- Two-axis code review (Standards + Spec) to a clean pass, plus a manually-requested Copilot
+  PR review (`gh pr edit <n> --add-reviewer '@copilot'`) since automatic Copilot review was
+  disabled repo-wide during this repo's earlier security-hardening pass.
+
+## Out of Scope
+
+- Any change to application behaviour, dependencies, or the app's own test suite.
+- The self-hosted runner's version/config — confirmed sufficient, not touched.
+- Consolidating this pattern into a shared composite action across other repos — this fix
+  stays local to `bromley-bin-reminder`.
+
+## Further Notes
+
+This is a small, well-scoped, low-risk change, part of a proven cross-repo pattern (first
+applied in `hypervolt-agile`, PR #68, merged 2026-08-11). No architectural decision is being
+made here that warrants an ADR — the design is already validated elsewhere.

--- a/.github/workflows/ci-arm64.yml
+++ b/.github/workflows/ci-arm64.yml
@@ -14,12 +14,12 @@ jobs:
       DOCKER_TARGET_PLATFORM: linux/arm/arm64
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Prepare
         if: success()
         id: prepare
-        run: | 
+        run: |
           echo "docker_platform=${DOCKER_TARGET_PLATFORM}" >> $GITHUB_OUTPUT
           echo "docker_image=${DOCKER_REGISTRY}/${DOCKER_IMAGE}" >> $GITHUB_OUTPUT
           echo "version=${GITHUB_RUN_NUMBER}" >> $GITHUB_OUTPUT
@@ -30,13 +30,6 @@ jobs:
           docker info
           docker ps
 
-      - name: Docker Login
-        if: success()
-        uses: docker/login-action@v2
-        with: 
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Get Docker Image Tag
         if: success()
         id: tag
@@ -46,8 +39,21 @@ jobs:
           if [ $branchName != 'main' ]; then image_tag='dev'; else image_tag='latest'; fi
           echo "tag=$(echo $image_tag)" >> $GITHUB_OUTPUT
 
-      - name: Docker Build and Push    
-        uses: docker/build-push-action@v4
+      - name: Docker Login and Build/Push
+        if: success()
+        uses: nick-fields/retry@v4
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          TAG: ${{ steps.prepare.outputs.docker_image }}:${{ steps.tag.outputs.tag }}
         with:
-          push: true
-          tags: ${{ steps.prepare.outputs.docker_image }}:${{ steps.tag.outputs.tag }}
+          max_attempts: 3
+          retry_wait_seconds: 15
+          timeout_minutes: 5
+          command: |
+            set -euo pipefail
+            echo "$DOCKERHUB_TOKEN" | docker login "$DOCKER_REGISTRY" --username "$DOCKERHUB_USERNAME" --password-stdin
+            # Build from the local checkout rather than a remote git#{sha} context — the
+            # remote-fetch path build-push-action used previously was the confirmed root
+            # cause of a transient CI failure in an earlier repo hardened with this pattern.
+            docker buildx build --push --tag "$TAG" .

--- a/.github/workflows/ci-arm64.yml
+++ b/.github/workflows/ci-arm64.yml
@@ -11,7 +11,6 @@ jobs:
     env:
       DOCKER_REGISTRY: docker.io
       DOCKER_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/bromley-bin-reminder
-      DOCKER_TARGET_PLATFORM: linux/arm/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -20,7 +19,6 @@ jobs:
         if: success()
         id: prepare
         run: |
-          echo "docker_platform=${DOCKER_TARGET_PLATFORM}" >> $GITHUB_OUTPUT
           echo "docker_image=${DOCKER_REGISTRY}/${DOCKER_IMAGE}" >> $GITHUB_OUTPUT
           echo "version=${GITHUB_RUN_NUMBER}" >> $GITHUB_OUTPUT
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+## Agent Standards
+
+See [.agent-docs/agent.md](.agent-docs/agent.md) for behavioural standards that apply to all AI agent work in this repository.


### PR DESCRIPTION
## Summary

- Bumps `actions/checkout` from `v2` to `v7` in `.github/workflows/ci-arm64.yml` — confirmed via each tag's `action.yml` that `v7` runs on `node24`. GitHub removes Node 20 support from Actions runners entirely on 2026-09-16.
- Replaces `docker/login-action` + `docker/build-push-action` (both `node20`) with a single `nick-fields/retry@v4`-wrapped shell step (`docker login` + `docker buildx build --push`), so a transient DNS/auth blip retries automatically instead of failing the whole build.
- Builds from the local checkout rather than a remote `git#{sha}` context — this was the confirmed root cause of a transient CI failure in an earlier repo hardened with this same pattern; documented inline with a YAML comment.
- Self-hosted `[ARM64]` runner confirmed on `2.336.0`, well above the `2.327.1` minimum required for node24 actions — no runner upgrade needed.
- Also bootstraps `.agent-docs/agent.md`, `.agent-docs/context.md`, and `CLAUDE.md` (separate commit) as part of this repo's first `/implement` run.

Part of a cross-repo CI hardening pass; same pattern already applied in `hypervolt-agile` (PR #68).

Closes #255

## Test plan

- [x] Pushed the branch and confirmed via `gh run watch` that the Docker Build/Publish workflow succeeds (run [31879615779](https://github.com/mholubinka1/bromley-bin-reminder/actions/runs/31879615779))
- [x] Confirmed via `gh run view <run-id> --log | grep -i deprecat` that no "Node.js 20 is deprecated" warning remains
- [x] Two-axis code review (Standards + Spec) to two consecutive clean passes
