### PR TITLE
chore: fix stale ARMv7 label in ci-arm64.yml workflow name

### DIFF
--- a/.github/workflows/ci-arm64.yml
+++ b/.github/workflows/ci-arm64.yml
@@ -1,4 +1,4 @@
-name: Docker Build/Publish Image - ARMv7
+name: Docker Build/Publish Image - ARM64
 
 on:
   push:


### PR DESCRIPTION
## Summary

The workflow's top-level `name:` field said "Docker Build/Publish Image - ARMv7", but everything else about it — the filename (`ci-arm64.yml`), the job ID (`ARM64_App_Image_Build_and_Push`), `runs-on: [ ARM64 ]`, and the Dockerfile's `linux-aarch64` geckodriver download — is ARM64 (64-bit), not ARMv7 (32-bit). This was flagged by Copilot as a suppressed review comment on PR #256 against the spec doc, which just echoed the workflow's own pre-existing (stale) name; fixing the workflow name directly here.

One-line change, no functional impact — display label only.

## Test plan

- [x] Pushed and confirmed via `gh run watch` that the workflow still runs successfully (run 32025444662)